### PR TITLE
Update code.js

### DIFF
--- a/sections/plugins/code.js
+++ b/sections/plugins/code.js
@@ -8,7 +8,7 @@ app.controller('customCtrl', ['$scope', function (scope) {
 app.directive('csSelect', function () {
     return {
         require: '^stTable',
-        template: '<input type="checkbox"/>',
+        template: '<input type="checkbox" ng-checked="row.isSelected"/>',
         scope: {
             row: '=csSelect'
         },


### PR DESCRIPTION
If rows are split across pages and the grid is sorted, the checkbox is no longer checked.  Might not be the best approach, but it works in my application.
